### PR TITLE
Remove bank name from extracted .wav file to avoid invalid character …

### DIFF
--- a/src/cktool/main.cpp
+++ b/src/cktool/main.cpp
@@ -858,8 +858,6 @@ bool extract(const char* path)
                 // TODO test for overwriting?
                 Path outPath(path);
                 outPath.setExtension(NULL);
-                outPath.append("_");
-                outPath.append(sample.name.getBuffer());
                 outPath.append("_extracted");
                 outPath.setExtension("wav");
 


### PR DESCRIPTION
…'/' in filename.

Because bank name may include invalid character '/' which destroys the filename.